### PR TITLE
Se crearon las siguientes tareas automatizadas con Gulp:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ Temporary Items
 .apdisk
 prepros.cfg
 .idea
+
+node_modules/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var gulp = require('gulp');
+var postcss = require('gulp-postcss');
+var autoprefixer = require('autoprefixer');
+var sass = require('gulp-sass');
+var jade = require('gulp-jade');
+var connect = require('gulp-connect');
+
+gulp.task('css', function () {
+  var processors = [
+    autoprefixer({ browsers: ['last 2 versions'] })
+  ];
+
+  return gulp.src('./scss/*.scss')
+    .pipe(sass().on('error', sass.logError))
+    .pipe(postcss(processors))
+    .pipe(gulp.dest('./css'))
+    .pipe(connect.reload());
+});
+
+gulp.task('html', function() {
+  gulp.src('./jade/*.jade')
+    .pipe(jade({
+      pretty: true
+    }))
+    .pipe(gulp.dest('./'))
+    .pipe(connect.reload());
+});
+
+gulp.task('connect', function() {
+  connect.server({
+    // root: '.',
+    port: 7070,
+    livereload: true
+  });
+});
+
+gulp.task('watch', ['css', 'html'], function () {
+  gulp.watch('./scss/**/*.scss', ['css']);
+  gulp.watch('./jade/**/*.jade', ['html']);
+});
+
+gulp.task('start', ['connect', 'watch']);
+
+gulp.task('default', ['css', 'html']);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "ed-grid",
+  "version": "1.2.0",
+  "description": "Framework de CSS puro para crear diseños web responsive y mobile first.",
+  "author": "Alvaro Felipe <informes@escueladigital.pe>",
+  "contributors": [
+    {
+      "name": "Daniel Guillermo Romero Gelvez",
+      "email": "danielromeroauk@gmail.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/escueladigital/ED-GRID"
+  },
+  "bugs": {
+    "url": "https://github.com/escueladigital/ED-GRID/issues"
+  },
+  "devDependencies": {
+    "autoprefixer": "^6.0.3",
+    "gulp": "^3.9.0",
+    "gulp-connect": "^2.2.0",
+    "gulp-jade": "^1.1.0",
+    "gulp-postcss": "^6.0.1",
+    "gulp-sass": "^2.0.4"
+  },
+  "license": "ISC"
+}


### PR DESCRIPTION
### gulp css
Compila el archivo `scss/estilos.scss`, el código CSS resultante de la compilación se localiza en `css/estilos.css`.

### gulp html
Compila los archivos `.jade` de la carpeta `jade/`, los archivos HTML resultantes de la compilación se localizan en la carpeta raíz del proyecto.

### gulp watch
Ejecuta las tareas `css` y `html`, luego queda escuchando los cambios de los archivos `.scss` y `.jade` de las carpetas y subcarpetas correspondientes para volver a ejecutar esas tareas de ser necesario.

### gulp start
Crea un livereload para los archivos `.css` y `.html` en la dirección `http://localhost:7070`, luego ejecuta la tarea `watch`. No es necesaria ninguna extensión en el navegador web.

### gulp
Ejecuta las tareas `css` y `html`.


## Archivos del commit:
        modified:   .gitignore
        new file:   gulpfile.js
        new file:   package.json