### PR TITLE
Se evita que alguna de las tareas watch se detenga cuando haya errores.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,12 +3,13 @@
 /**
  * Dependencias
  */
-var gulp = require('gulp');
-var postcss = require('gulp-postcss');
-var autoprefixer = require('autoprefixer');
-var sass = require('gulp-sass');
-var jade = require('gulp-jade');
-var connect = require('gulp-connect');
+var gulp = require('gulp'),
+    plumber = require('gulp-plumber'),
+    postcss = require('gulp-postcss'),
+    autoprefixer = require('autoprefixer'),
+    sass = require('gulp-sass'),
+    jade = require('gulp-jade'),
+    connect = require('gulp-connect');
 
 /**
  * Variable de entorno.
@@ -31,6 +32,7 @@ gulp.task('sass', function () {
 
   return gulp.src('./scss/*.scss')
     .pipe(sass().on('error', sass.logError))
+    .pipe(plumber())
     .pipe(postcss(processors))
     .pipe(gulp.dest('./css'))
     .pipe(connect.reload());
@@ -43,6 +45,7 @@ gulp.task('sass', function () {
  */
 gulp.task('jade', function() {
   gulp.src('./jade/*.jade')
+    .pipe(plumber())
     .pipe(jade({
       pretty: true
     }))

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp": "^3.9.0",
     "gulp-connect": "^2.2.0",
     "gulp-jade": "^1.1.0",
+    "gulp-plumber": "^1.0.1",
     "gulp-postcss": "^6.0.1",
     "gulp-sass": "^2.0.4"
   },


### PR DESCRIPTION
Se evita que alguna de las tareas watch se detenga cuando haya errores en el código jade o en alguno de los plugins postcss.

La terminal muestra el error cometido y la tarea watch continua escuchando las correcciones que se apliquen, de esta forma no es necesario estar volviendo a iniciar la tarea manualmente cuando se tengan errores de sintaxis.

```
Changes committed:
	modified:   gulpfile.js
	modified:   package.json
```