### PR TITLE
Actualizar DOCTYPE en jade

### DIFF
--- a/jade/index.jade
+++ b/jade/index.jade
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+doctype html
 html(lang="es")
   head
     meta(charset="UTF-8")


### PR DESCRIPTION
según la referencia de Jade el código debería sere de esta manera:

```jade
doctype html
html(lang="en")
  head
    title= pageTitle
```

Ya que al ser generado en este caso con gulp.js se transformara a <!DOCTYPE html>. 
Mas info: en el frontpage de Jade http://jade-lang.com/
![screenshot from 2015-11-13 11 13 18](https://cloud.githubusercontent.com/assets/10109689/11150021/da7f1aaa-89f7-11e5-9322-d3595d79dd9a.png)
